### PR TITLE
Update install_colabbatch_linux.sh

### DIFF
--- a/install_colabbatch_linux.sh
+++ b/install_colabbatch_linux.sh
@@ -16,6 +16,7 @@ export PATH="${COLABFOLDDIR}/conda/condabin:${PATH}"
 conda create -p $COLABFOLDDIR/colabfold-conda python=3.10 -y
 conda activate $COLABFOLDDIR/colabfold-conda
 conda update -n base conda -y
+conda install git
 conda install -c conda-forge python=3.10 cudnn==8.2.1.32 cudatoolkit==11.6.0 openmm==7.7.0 pdbfixer -y
 # Download the updater
 wget -qnc https://raw.githubusercontent.com/YoshitakaMo/localcolabfold/main/update_linux.sh --no-check-certificate


### PR DESCRIPTION
The history script didn't check whether Git exists, and there is no clear warning if Conda doesn't have Git. Therefore, I added 'conda install git' to ensure that the script can work better.